### PR TITLE
Fixes to fairness and drift notebooks for the release branch directly

### DIFF
--- a/starter-examples/starter-drift-part-1.ipynb
+++ b/starter-examples/starter-drift-part-1.ipynb
@@ -104,7 +104,7 @@
     "# make all float and make index ids\n",
     "san_francisco = san_francisco.astype(float).reset_index(names=\"id\")\n",
     "seattle = seattle.astype(float).reset_index(names=\"id\")\n",
-    "austin = austin.astype(float).reset_index(names=\"id\")\n"
+    "austin = austin.astype(float).reset_index(names=\"id\")"
    ]
   },
   {
@@ -441,6 +441,7 @@
    },
    "outputs": [],
    "source": [
+    "tru.set_influences_background_data_split(\"San Francisco\")\n",
     "tru.set_data_split(\"San Francisco\")\n",
     "san_francisco_mean_price = tru.get_ys().mean()\n",
     "tru.set_data_split(\"Seattle\")\n",
@@ -522,7 +523,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.11.4 64-bit ('saas_ga_release')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -536,7 +537,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.6"
   },
   "vscode": {
    "interpreter": {

--- a/starter-examples/starter-drift-part-1.ipynb
+++ b/starter-examples/starter-drift-part-1.ipynb
@@ -43,7 +43,40 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install --upgrade truera"
+    "#! pip install --upgrade truera"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# delete this cell\n",
+    "# delete all cell output\n",
+    "# install truera\n",
+    "# uncomment out TrueraWorkspace\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "os.chdir(\"/Users/davidkurokawa/Work/code/truera/truera/python\")\n",
+    "if \"/Users/davidkurokawa/Work/code/truera/truera/python\" not in sys.path:\n",
+    "    sys.path.append(\"/Users/davidkurokawa/Work/code/truera/truera/python\")\n",
+    "\n",
+    "from truera.client.truera_authentication import BasicAuthentication\n",
+    "from truera.client.truera_authentication import TokenAuthentication\n",
+    "from truera.client.truera_workspace import TrueraWorkspace\n",
+    "\n",
+    "TRUERA_URL = \"https://app.truera.net\"\n",
+    "AUTH_TOKEN = \"eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJUcnVFcmFfVG9rZW5fSXNzdWVyX2F3cy1wcmQtdmExLWluZnJhMS1hcHAtcHJkIiwiaWF0IjoxNjkxMDIwNzI2LCJleHAiOjE2OTEyNzk5MjYsInN1YiI6ImIxNTgxY2Q2ZGNmZjhlYjBhZjc1ZGMyN2Q0MDgzY2EzIiwiaWQiOiJiMTU4MWNkNmRjZmY4ZWIwYWY3NWRjMjdkNDA4M2NhMyIsIm5hbWUiOiJEYXZpZCBLdXJva2F3YSIsImVtYWlsIjoiZGF2aWRAdHJ1ZXJhLmNvbSIsInRlbmFudF9pZCI6IjE0MjExOTEyLTY5YzgtNDFhMC1hZDQ1LTdhZDIzOTVmYjkzYiJ9.eSi0gllMkvP1D4C55cTidH4ejRrj3Pvcb0EH5qPvvyA2fQGQLR-ZEqDvgzmmMr_4zvCBYDeUJMTwisCzXzrbzg\"\n",
+    "tru = TrueraWorkspace(TRUERA_URL, TokenAuthentication(AUTH_TOKEN))\n",
+    "\n",
+    "TRUERA_URL = \"http://localhost:8000\"\n",
+    "AUTH_TOKEN = \"\"\n",
+    "tru = TrueraWorkspace(TRUERA_URL, BasicAuthentication(\"ailens\", \"ailens123\"))\n",
+    "\n",
+    "if \"Starter Example Companion - Drift\" in tru.get_projects():\n",
+    "    tru.delete_project(\"Starter Example Companion - Drift\")"
    ]
   },
   {
@@ -75,8 +108,8 @@
     "from truera.client.truera_authentication import TokenAuthentication\n",
     "from truera.client.ingestion import ModelOutputContext, ColumnSpec\n",
     "\n",
-    "auth = TokenAuthentication(AUTH_TOKEN)\n",
-    "tru = TrueraWorkspace(TRUERA_URL, auth)"
+    "#auth = TokenAuthentication(AUTH_TOKEN)\n",
+    "#tru = TrueraWorkspace(TRUERA_URL, auth)"
    ]
   },
   {

--- a/starter-examples/starter-drift-part-1.ipynb
+++ b/starter-examples/starter-drift-part-1.ipynb
@@ -43,40 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#! pip install --upgrade truera"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# delete this cell\n",
-    "# delete all cell output\n",
-    "# install truera\n",
-    "# uncomment out TrueraWorkspace\n",
-    "\n",
-    "import os\n",
-    "import sys\n",
-    "os.chdir(\"/Users/davidkurokawa/Work/code/truera/truera/python\")\n",
-    "if \"/Users/davidkurokawa/Work/code/truera/truera/python\" not in sys.path:\n",
-    "    sys.path.append(\"/Users/davidkurokawa/Work/code/truera/truera/python\")\n",
-    "\n",
-    "from truera.client.truera_authentication import BasicAuthentication\n",
-    "from truera.client.truera_authentication import TokenAuthentication\n",
-    "from truera.client.truera_workspace import TrueraWorkspace\n",
-    "\n",
-    "TRUERA_URL = \"https://app.truera.net\"\n",
-    "AUTH_TOKEN = \"eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJUcnVFcmFfVG9rZW5fSXNzdWVyX2F3cy1wcmQtdmExLWluZnJhMS1hcHAtcHJkIiwiaWF0IjoxNjkxMDIwNzI2LCJleHAiOjE2OTEyNzk5MjYsInN1YiI6ImIxNTgxY2Q2ZGNmZjhlYjBhZjc1ZGMyN2Q0MDgzY2EzIiwiaWQiOiJiMTU4MWNkNmRjZmY4ZWIwYWY3NWRjMjdkNDA4M2NhMyIsIm5hbWUiOiJEYXZpZCBLdXJva2F3YSIsImVtYWlsIjoiZGF2aWRAdHJ1ZXJhLmNvbSIsInRlbmFudF9pZCI6IjE0MjExOTEyLTY5YzgtNDFhMC1hZDQ1LTdhZDIzOTVmYjkzYiJ9.eSi0gllMkvP1D4C55cTidH4ejRrj3Pvcb0EH5qPvvyA2fQGQLR-ZEqDvgzmmMr_4zvCBYDeUJMTwisCzXzrbzg\"\n",
-    "tru = TrueraWorkspace(TRUERA_URL, TokenAuthentication(AUTH_TOKEN))\n",
-    "\n",
-    "TRUERA_URL = \"http://localhost:8000\"\n",
-    "AUTH_TOKEN = \"\"\n",
-    "tru = TrueraWorkspace(TRUERA_URL, BasicAuthentication(\"ailens\", \"ailens123\"))\n",
-    "\n",
-    "if \"Starter Example Companion - Drift\" in tru.get_projects():\n",
-    "    tru.delete_project(\"Starter Example Companion - Drift\")"
+    "! pip install truera"
    ]
   },
   {
@@ -108,8 +75,8 @@
     "from truera.client.truera_authentication import TokenAuthentication\n",
     "from truera.client.ingestion import ModelOutputContext, ColumnSpec\n",
     "\n",
-    "#auth = TokenAuthentication(AUTH_TOKEN)\n",
-    "#tru = TrueraWorkspace(TRUERA_URL, auth)"
+    "auth = TokenAuthentication(AUTH_TOKEN)\n",
+    "tru = TrueraWorkspace(TRUERA_URL, auth)"
    ]
   },
   {

--- a/starter-examples/starter-drift-part-2.ipynb
+++ b/starter-examples/starter-drift-part-2.ipynb
@@ -55,7 +55,37 @@
    },
    "outputs": [],
    "source": [
-    "! pip install --upgrade truera"
+    "#! pip install --upgrade truera"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# delete this cell\n",
+    "# delete all cell output\n",
+    "# install truera\n",
+    "# uncomment out TrueraWorkspace\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "os.chdir(\"/Users/davidkurokawa/Work/code/truera/truera/python\")\n",
+    "if \"/Users/davidkurokawa/Work/code/truera/truera/python\" not in sys.path:\n",
+    "    sys.path.append(\"/Users/davidkurokawa/Work/code/truera/truera/python\")\n",
+    "\n",
+    "from truera.client.truera_authentication import BasicAuthentication\n",
+    "from truera.client.truera_authentication import TokenAuthentication\n",
+    "from truera.client.truera_workspace import TrueraWorkspace\n",
+    "\n",
+    "TRUERA_URL = \"https://app.truera.net\"\n",
+    "AUTH_TOKEN = \"eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJUcnVFcmFfVG9rZW5fSXNzdWVyX2F3cy1wcmQtdmExLWluZnJhMS1hcHAtcHJkIiwiaWF0IjoxNjkxMDIwNzI2LCJleHAiOjE2OTEyNzk5MjYsInN1YiI6ImIxNTgxY2Q2ZGNmZjhlYjBhZjc1ZGMyN2Q0MDgzY2EzIiwiaWQiOiJiMTU4MWNkNmRjZmY4ZWIwYWY3NWRjMjdkNDA4M2NhMyIsIm5hbWUiOiJEYXZpZCBLdXJva2F3YSIsImVtYWlsIjoiZGF2aWRAdHJ1ZXJhLmNvbSIsInRlbmFudF9pZCI6IjE0MjExOTEyLTY5YzgtNDFhMC1hZDQ1LTdhZDIzOTVmYjkzYiJ9.eSi0gllMkvP1D4C55cTidH4ejRrj3Pvcb0EH5qPvvyA2fQGQLR-ZEqDvgzmmMr_4zvCBYDeUJMTwisCzXzrbzg\"\n",
+    "tru = TrueraWorkspace(TRUERA_URL, TokenAuthentication(AUTH_TOKEN))\n",
+    "\n",
+    "TRUERA_URL = \"http://localhost:8000\"\n",
+    "AUTH_TOKEN = \"\"\n",
+    "tru = TrueraWorkspace(TRUERA_URL, BasicAuthentication(\"ailens\", \"ailens123\"))"
    ]
   },
   {
@@ -88,8 +118,8 @@
     "from truera.client.truera_authentication import TokenAuthentication\n",
     "from truera.client.ingestion import ModelOutputContext, ColumnSpec\n",
     "\n",
-    "auth = TokenAuthentication(AUTH_TOKEN)\n",
-    "tru = TrueraWorkspace(TRUERA_URL, auth)\n",
+    "#auth = TokenAuthentication(AUTH_TOKEN)\n",
+    "#tru = TrueraWorkspace(TRUERA_URL, auth)\n",
     "\n",
     "# note: we'll periodically toggle between local and remote so we can interact with our remote deployment as well."
    ]
@@ -518,6 +548,8 @@
     "        pre_data_col_names=list(seattle.columns.drop([\"id\",\"price\",\"availability_90\",\"availability_365\"])),\n",
     "        label_col_names=\"price\")\n",
     ")\n",
+    "tru.set_influences_background_data_split(\"San Francisco\")\n",
+    "\n",
     "# register the model\n",
     "tru.add_python_model(\n",
     "    \"model_3\",\n",
@@ -655,7 +687,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.11.4 64-bit ('saas_ga_release')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -669,7 +701,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.6"
   },
   "vscode": {
    "interpreter": {

--- a/starter-examples/starter-drift-part-2.ipynb
+++ b/starter-examples/starter-drift-part-2.ipynb
@@ -55,37 +55,7 @@
    },
    "outputs": [],
    "source": [
-    "#! pip install --upgrade truera"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# delete this cell\n",
-    "# delete all cell output\n",
-    "# install truera\n",
-    "# uncomment out TrueraWorkspace\n",
-    "\n",
-    "import os\n",
-    "import sys\n",
-    "os.chdir(\"/Users/davidkurokawa/Work/code/truera/truera/python\")\n",
-    "if \"/Users/davidkurokawa/Work/code/truera/truera/python\" not in sys.path:\n",
-    "    sys.path.append(\"/Users/davidkurokawa/Work/code/truera/truera/python\")\n",
-    "\n",
-    "from truera.client.truera_authentication import BasicAuthentication\n",
-    "from truera.client.truera_authentication import TokenAuthentication\n",
-    "from truera.client.truera_workspace import TrueraWorkspace\n",
-    "\n",
-    "TRUERA_URL = \"https://app.truera.net\"\n",
-    "AUTH_TOKEN = \"eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJUcnVFcmFfVG9rZW5fSXNzdWVyX2F3cy1wcmQtdmExLWluZnJhMS1hcHAtcHJkIiwiaWF0IjoxNjkxMDIwNzI2LCJleHAiOjE2OTEyNzk5MjYsInN1YiI6ImIxNTgxY2Q2ZGNmZjhlYjBhZjc1ZGMyN2Q0MDgzY2EzIiwiaWQiOiJiMTU4MWNkNmRjZmY4ZWIwYWY3NWRjMjdkNDA4M2NhMyIsIm5hbWUiOiJEYXZpZCBLdXJva2F3YSIsImVtYWlsIjoiZGF2aWRAdHJ1ZXJhLmNvbSIsInRlbmFudF9pZCI6IjE0MjExOTEyLTY5YzgtNDFhMC1hZDQ1LTdhZDIzOTVmYjkzYiJ9.eSi0gllMkvP1D4C55cTidH4ejRrj3Pvcb0EH5qPvvyA2fQGQLR-ZEqDvgzmmMr_4zvCBYDeUJMTwisCzXzrbzg\"\n",
-    "tru = TrueraWorkspace(TRUERA_URL, TokenAuthentication(AUTH_TOKEN))\n",
-    "\n",
-    "TRUERA_URL = \"http://localhost:8000\"\n",
-    "AUTH_TOKEN = \"\"\n",
-    "tru = TrueraWorkspace(TRUERA_URL, BasicAuthentication(\"ailens\", \"ailens123\"))"
+    "! pip install truera"
    ]
   },
   {
@@ -118,10 +88,8 @@
     "from truera.client.truera_authentication import TokenAuthentication\n",
     "from truera.client.ingestion import ModelOutputContext, ColumnSpec\n",
     "\n",
-    "#auth = TokenAuthentication(AUTH_TOKEN)\n",
-    "#tru = TrueraWorkspace(TRUERA_URL, auth)\n",
-    "\n",
-    "# note: we'll periodically toggle between local and remote so we can interact with our remote deployment as well."
+    "auth = TokenAuthentication(AUTH_TOKEN)\n",
+    "tru = TrueraWorkspace(TRUERA_URL, auth)"
    ]
   },
   {

--- a/starter-examples/starter-fairness-part-1.ipynb
+++ b/starter-examples/starter-fairness-part-1.ipynb
@@ -475,9 +475,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.11.4 64-bit ('saas_ga_release')",
+   "display_name": "demo3",
    "language": "python",
-   "name": "python3"
+   "name": "demo3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -489,7 +489,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.6"
   },
   "vscode": {
    "interpreter": {

--- a/starter-examples/starter-fairness-part-2.ipynb
+++ b/starter-examples/starter-fairness-part-2.ipynb
@@ -425,14 +425,14 @@
    "outputs": [],
    "source": [
     "tru.set_model(model_name_v2)\n",
-    "explainer = tru.get_explainer(base_data_split=\"2014-CA\")\n",
     "tru.set_data_split(\"2014-CA\")\n",
     "tru.add_segment_group(\n",
     "    \"Sex + Label\",\n",
     "    {\n",
     "        \"Other\": \"(Sex == 'Male') OR (_DATA_GROUND_TRUTH == 0)\",\n",
     "         \"Female + Label 1\": \"(Sex == 'Female') AND (_DATA_GROUND_TRUTH == 1)\"\n",
-    "    })"
+    "    })\n",
+    "explainer = tru.get_explainer(base_data_split=\"2014-CA\")"
    ]
   },
   {
@@ -698,9 +698,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.11.4 64-bit ('saas_ga_release')",
+   "display_name": "demo3",
    "language": "python",
-   "name": "python3"
+   "name": "demo3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -712,7 +712,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.6"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Fixes to fairness and drift notebooks:
1. Doing a `set_influences_background_data_split` when necessary.
2. Moving a `get_explainer` call since it downloads the project when it does that and doesn't again for now.